### PR TITLE
Make base URL overrideable without affecting path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+bin/
 coverage/

--- a/purge.go
+++ b/purge.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 )
@@ -57,14 +56,6 @@ func NewPurgeWithFastlyURLAndAPIKey(fastlyURL string, apiKey string) *Purge {
 		FastlyURL: fastlyURL,
 		APIKey:    apiKey,
 	}
-}
-
-type nopCloser struct {
-	io.Reader
-}
-
-func (nopCloser) Close() error {
-	return nil
 }
 
 func (p *Purge) purgeRequest(reqURL string, httpMethod string, purgeMode PurgeMode, idExpected bool) (string, error) {

--- a/purge.go
+++ b/purge.go
@@ -1,12 +1,12 @@
 package fastlypurge
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 type PurgeResponse struct {
@@ -31,30 +31,31 @@ const (
 )
 
 type Purge struct {
-	APIKey      string
-	OverrideURL string
+	APIKey    string
+	FastlyURL string
 }
 
 func NewPurge() *Purge {
 	return &Purge{}
 }
 
-func newPurgeWithOverrideURL(overrideURL string) *Purge {
+func newPurgeWithFastlyURL(fastlyURL string) *Purge {
 	return &Purge{
-		OverrideURL: overrideURL,
+		FastlyURL: fastlyURL,
 	}
 }
 
 func NewPurgeWithAPIKey(apiKey string) *Purge {
 	return &Purge{
-		APIKey: apiKey,
+		FastlyURL: PURGE_API_ENDPOINT,
+		APIKey:    apiKey,
 	}
 }
 
-func newPurgeWithOverrideURLAndAPIKey(overrideURL string, apiKey string) *Purge {
+func newPurgeWithFastlyURLAndAPIKey(fastlyURL string, apiKey string) *Purge {
 	return &Purge{
-		OverrideURL: overrideURL,
-		APIKey:      apiKey,
+		FastlyURL: fastlyURL,
+		APIKey:    apiKey,
 	}
 }
 
@@ -62,26 +63,23 @@ type nopCloser struct {
 	io.Reader
 }
 
-func (nopCloser) Close() error { return nil }
+func (nopCloser) Close() error {
+	return nil
+}
 
-func (p *Purge) purgeRequest(url string, httpMethod string, purgeMode PurgeMode, idExpected bool) (string, error) {
+func (p *Purge) purgeRequest(reqURL string, httpMethod string, purgeMode PurgeMode, idExpected bool) (string, error) {
 	if purgeMode != PURGE_MODE_INSTANT && purgeMode != PURGE_MODE_SOFT {
 		return "", errors.New("Invalid Purge Mode")
 	}
 
-	// If the OverrideURL is set use this, to allow for testing
-	reqURL := url
-	if p.OverrideURL != "" {
-		reqURL = p.OverrideURL
+	_, err := url.ParseRequestURI(reqURL)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse URL, with error: %s", err)
 	}
 
 	req, err := http.NewRequest(httpMethod, reqURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create HTTP request, with error: %s", err.Error())
-	}
-
-	if p.OverrideURL != "" {
-		req.Body = nopCloser{bytes.NewBufferString(url)}
 	}
 
 	if purgeMode == PURGE_MODE_SOFT {
@@ -135,7 +133,7 @@ func (p *Purge) PurgeAll(service string, purgeMode PurgeMode) error {
 		return errors.New("Service is required for Purge All")
 	}
 
-	url := fmt.Sprintf("%s/service/%s/purge_all", PURGE_API_ENDPOINT, service)
+	url := fmt.Sprintf("%s/service/%s/purge_all", p.FastlyURL, service)
 
 	_, err := p.purgeRequest(url, "POST", purgeMode, false)
 
@@ -153,7 +151,7 @@ func (p *Purge) PurgeKey(service string, key string, purgeMode PurgeMode) error 
 		return errors.New("Key is required for Purge By Key")
 	}
 
-	url := fmt.Sprintf("%s/service/%s/purge/%s", PURGE_API_ENDPOINT, service, key)
+	url := fmt.Sprintf("%s/service/%s/purge/%s", p.FastlyURL, service, key)
 
 	_, err := p.purgeRequest(url, "POST", purgeMode, false)
 

--- a/purge.go
+++ b/purge.go
@@ -52,7 +52,7 @@ func NewPurgeWithAPIKey(apiKey string) *Purge {
 	}
 }
 
-func newPurgeWithFastlyURLAndAPIKey(fastlyURL string, apiKey string) *Purge {
+func NewPurgeWithFastlyURLAndAPIKey(fastlyURL string, apiKey string) *Purge {
 	return &Purge{
 		FastlyURL: fastlyURL,
 		APIKey:    apiKey,

--- a/purge_test.go
+++ b/purge_test.go
@@ -224,7 +224,7 @@ func (s *FastlyPurgeSuite) TestPurgeAllInstant() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeAll(VALID_PURGE_SERVICE, PURGE_MODE_INSTANT)
@@ -259,7 +259,7 @@ func (s *FastlyPurgeSuite) TestPurgeAllInstantErrorNoService() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeAll("", PURGE_MODE_INSTANT)
@@ -277,7 +277,7 @@ func (s *FastlyPurgeSuite) TestPurgeAllSoft() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeAll(VALID_PURGE_SERVICE, PURGE_MODE_SOFT)
@@ -294,7 +294,7 @@ func (s *FastlyPurgeSuite) TestPurgeKeyInstant() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeKey(VALID_PURGE_SERVICE, VALID_PURGE_KEY, PURGE_MODE_INSTANT)
@@ -329,7 +329,7 @@ func (s *FastlyPurgeSuite) TestPurgeKeyInstantErrorNoService() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeKey("", VALID_PURGE_KEY, PURGE_MODE_INSTANT)
@@ -347,7 +347,7 @@ func (s *FastlyPurgeSuite) TestPurgeKeyInstantErrorNoKey() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeKey(VALID_PURGE_SERVICE, "", PURGE_MODE_INSTANT)
@@ -365,7 +365,7 @@ func (s *FastlyPurgeSuite) TestPurgeKeySoft() {
 	}))
 	defer ts.Close()
 
-	p := newPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
+	p := NewPurgeWithFastlyURLAndAPIKey(ts.URL, VALID_PURGE_API_KEY)
 	assert.NotNil(s.T(), p)
 
 	err := p.PurgeKey(VALID_PURGE_SERVICE, VALID_PURGE_KEY, PURGE_MODE_SOFT)


### PR DESCRIPTION
I'd like to be able to use this in other components and be able to point it at a stub web server for testing.

Currently, the only method for overriding a URL will override the whole URL (including path) for all calls.